### PR TITLE
Fix unit tests

### DIFF
--- a/__tests__/build.js
+++ b/__tests__/build.js
@@ -22,6 +22,9 @@ afterEach(() => {
   if (util.isInstalled.mock) {
     util.isInstalled.mockRestore();
   }
+  if (child_process.exec.mock) {
+    child_process.exec.mockReset();
+  }
 });
 
 describe("Test build", () => {


### PR DESCRIPTION
Mock implementation of exec wasn't being called and needed
to be cleared in order to not interfere with other test.