### PR TITLE
Remove confusing line

### DIFF
--- a/template/manifest.xml
+++ b/template/manifest.xml
@@ -3,7 +3,6 @@
           ml:version_name="0.0.1"
           ml:version_code="1">
   <application ml:visible_name="MagicScript Hello Sample"
-               ml:application_type="untrusted"
                ml:sdk_version="1.0">
     <component ml:name=".universe"
                ml:visible_name="MagicScript Hello Sample"


### PR DESCRIPTION
`untrusted` is the default behavior for the runtime and what virtually all 3rd party apps will be using.  It will confuse newcomers less if we don't have this field in the template.