### PR TITLE
Add tail data when debuggable is false

### DIFF
--- a/__tests__/mxs-sign-util.js
+++ b/__tests__/mxs-sign-util.js
@@ -160,6 +160,10 @@ describe('Test mxs-sign-util', () => {
       expect(node.includes('sign-file')).toBeTruthy();
       cb();
     });
+    exec.mockImplementationOnce((node, cb) => {
+      expect(node.includes('python')).toBeTruthy();
+      cb();
+    });
     try {
       mxsSignUtil.signDigest();
       expect(true).toBe(true);
@@ -174,6 +178,16 @@ describe('Test mxs-sign-util', () => {
     process.env['MLCERT'] = 'test';
     jest.spyOn(which, 'sync').mockImplementationOnce(() => {
       return '/asdf/mabu';
+    });
+    exec.mockImplementationOnce((node, cb) => {
+      expect(node.includes('python')).toBeTruthy();
+      var error = console.error;
+      console.error = jest.fn().mockImplementation((log, data) => {
+        expect(log).toBe('Error Adding tail data:');
+        expect(data).toBe('err');
+      });
+      cb('err');
+      console.error = error;
     });
     execFile.mockImplementationOnce((node, command, cb) => {
       expect(node.includes('sign-file')).toBeTruthy();

--- a/util/mxs-sign-util.js
+++ b/util/mxs-sign-util.js
@@ -148,7 +148,7 @@ module.exports = {
     const script = path.join(mlsdkRoot, '/tools/mabu/src/taildata_v3.py');
 
     let tailDataCommand = `${python} ${script} --sbox USER`;
-    if (argv.debug) tailDataCommand += ' --debuggable';
+    if (debug) tailDataCommand += ' --debuggable';
     tailDataCommand += ` ${DIGEST_PATH}`;
 
     console.info('Adding tail data');

--- a/util/mxs-sign-util.js
+++ b/util/mxs-sign-util.js
@@ -140,17 +140,17 @@ module.exports = {
       );
     }.bind(this);
 
-    if (!debug) {
-      signFile();
-      return;
-    }
-    let python = path.join(mlsdkRoot,
+    const python = path.join(mlsdkRoot,
       process.platform === 'win32'
         ? '/tools/python3/python.exe'
         : '/tools/python3/bin/python3.5'
     );
-    let script = path.join(mlsdkRoot, '/tools/mabu/src/taildata_v3.py');
-    let tailDataCommand = `${python} ${script} --sbox USER --debuggable ${this.DIGEST_PATH}`;
+    const script = path.join(mlsdkRoot, '/tools/mabu/src/taildata_v3.py');
+
+    let tailDataCommand = `${python} ${script} --sbox USER`;
+    if (argv.debug) tailDataCommand += ' --debuggable';
+    tailDataCommand += ` ${DIGEST_PATH}`;
+
     console.info('Adding tail data');
     exec(tailDataCommand, (err, stdout, stderr) => {
       console.log(stdout);


### PR DESCRIPTION
For MLW store submissions, the debuggable flag must be set to `false`.  
This PR fixes an issue where the tail data was excluded in this case.  The tail data is required for store submissions, so we need to make sure its still added.
