### PR TITLE
Run npm install with inherited stdio

### DIFF
--- a/commands/build.js
+++ b/commands/build.js
@@ -1,6 +1,6 @@
 // Copyright (c) 2019 Magic Leap, Inc. All Rights Reserved
 // Distributed under Apache 2.0 License. See LICENSE file in the project root for full license information.
-const { exec } = require('child_process');
+const { exec, spawn } = require('child_process');
 const fs = require('fs');
 const util = require('../lib/util');
 
@@ -9,11 +9,16 @@ function npmInstallIfNeeded (callback) {
     callback();
   } else {
     console.log('npm install: installing');
-    exec('npm install', (err, stdout, stderr) => {
-      if (err) {
-        process.stdout.write(stdout);
-        process.stderr.write(stderr);
-        throw err;
+    const proc = spawn('npm', ['install'], { stdio: 'inherit' });
+    proc.on('error', function (err) {
+      throw err;
+    });
+    proc.on('exit', function (code, signal) {
+      if (signal !== null) {
+        throw Error(`npm install failed with signal: ${signal}`);
+      }
+      if (code !== 0) {
+        throw Error(`npm install failed with code: ${code}`);
       }
       console.log('npm install: success');
       callback();

--- a/commands/build.js
+++ b/commands/build.js
@@ -8,6 +8,7 @@ function npmInstallIfNeeded (callback) {
   if (fs.existsSync('node_modules')) {
     callback();
   } else {
+    console.log('npm install: installing');
     exec('npm install', (err, stdout, stderr) => {
       if (err) {
         process.stdout.write(stdout);


### PR DESCRIPTION
This changes the `npm install` command to run using `spawn` and inherits stdio.
This results in the end user being able to watch the progress from `npm` when installing dependencies.
This also helps communicate that the install is happening to the user. Previously, the `magic-script` CLI would appear to hang / freeze while this process occurred.

Updated the tests to handle using `spawn` as well.

![magic-script_npm_install](https://user-images.githubusercontent.com/332384/58764460-2c081980-8535-11e9-9370-433a3d82378b.gif)

