### PR TITLE
Fix build and install

### DIFF
--- a/__tests__/build.js
+++ b/__tests__/build.js
@@ -90,7 +90,7 @@ describe('Test build', () => {
         expect(command).toBe('mabu -t device app.package');
         jest.spyOn(util, 'findPackageName').mockReturnValueOnce('com.abc');
         child_process.exec.mockImplementationOnce((command, callback) => {
-          expect(command).toBe('mldb install  my/path.mpk');
+          expect(command).toBe('mldb install  ');
           callback(null, 'install success');
         });
         util.isInstalled = jest.fn().mockImplementationOnce((packageName, callback) => {

--- a/commands/build.js
+++ b/commands/build.js
@@ -72,6 +72,7 @@ function buildLumin (argv) {
       }
       console.log('built package: ' + mpkFile);
       if (argv.install) {
+        argv.path = mpkFile;
         util.installPackage(argv);
       }
     });


### PR DESCRIPTION
Fix a bug with running `magic-script build -i`.

```
> magic-script build -i
Adding tail data
Tail data added successfully to 'digest.sha512.signed'


built package: .out/app/app.mpk

mldb install -u undefined

usage:
  mldb install [-u] <mpk-file> - install a package file
                                   (-u: update installation)
error: File not found: 'undefined'
/Users/bchapman/dev/magic-script-cli/lib/util.js:94
          throw err;
          ^

Error: Command failed: mldb install -u undefined
error: File not found: 'undefined'

    at ChildProcess.exithandler (child_process.js:275:12)
    at emitTwo (events.js:126:13)
    at ChildProcess.emit (events.js:214:7)
    at maybeClose (internal/child_process.js:925:16)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:209:5)
```

This was failing due to getting an `undefined` for sourcing the package name.