### PR TITLE
Fix app ID regex for init command

### DIFF
--- a/commands/init.js
+++ b/commands/init.js
@@ -11,6 +11,12 @@ var visibleName;
 var folderName;
 var immersive;
 
+const validatePackageId = (packageId) => util.isValidPackageId(packageId) ? true
+  : 'Invalid package ID. Must match ' + util.PackageIdRegex.toString();
+
+const validateFolderName = (folderName) => util.isValidFolderName(folderName) ? true
+  : 'Invalid folder name. Must match ' + util.FolderNameRegex.toString();
+
 const askQuestions = () => {
   const questions = [
     {
@@ -23,14 +29,14 @@ const askQuestions = () => {
       name: 'APPID',
       type: 'input',
       message: 'What is the app ID of your application?',
-      validate: util.isValidPackageId,
+      validate: validatePackageId,
       default: packageName
     },
     {
       name: 'FOLDERNAME',
       type: 'input',
       message: 'In which folder do you want to save this project?',
-      validate: util.isValidFolderName,
+      validate: validateFolderName,
       default: folderName
     },
     {

--- a/commands/init.js
+++ b/commands/init.js
@@ -38,7 +38,7 @@ const askQuestions = () => {
       type: 'list',
       message: 'What app type do you want?',
       choices: ['Landscape', 'Immersive', 'Components'],
-      default: "Landscape"
+      default: 'Landscape'
     }
   ];
   return inquirer.prompt(questions);
@@ -82,18 +82,16 @@ function copyFiles (srcPath, destPath) {
 }
 
 module.exports = argv => {
-  let nameRegex = /^([A-Za-z\-\_\d])+$/;
-  let idRegex = /^[a-z0-9_]+(\.[a-z0-9_]+)*(-[a-zA-Z0-9]*)?$/i;
   if (argv.visibleName) {
     visibleName = argv.visibleName;
   }
-  if (argv.folderName && nameRegex.test(argv.folderName)) {
+  if (argv.folderName && util.isValidFolderName(argv.folderName)) {
     folderName = argv.folderName;
     if (!visibleName) {
       visibleName = folderName;
     }
   }
-  if (argv.folderName && idRegex.test(argv.packageName)) {
+  if (argv.packageName && util.isValidPackageId(argv.packageName)) {
     packageName = argv.packageName;
   }
   const currentDirectory = process.cwd();
@@ -108,8 +106,9 @@ module.exports = argv => {
     folderName = answers['FOLDERNAME'];
     visibleName = answers['APPNAME'];
     let appType = answers['APPTYPE'];
-    immersive = appType === 'Immersive' || argv.immersive
-    if (appType == 'Components') {
+
+    immersive = appType === 'Immersive' || argv.immersive;
+    if (appType === 'Components') {
       immersive = false;
       templatePath = `${__dirname}/../template_components`;
     }

--- a/lib/util.js
+++ b/lib/util.js
@@ -100,11 +100,11 @@ module.exports.installPackage = function (argv) {
 };
 
 module.exports.isValidPackageId = function (packageId) {
-  let regex = /^[a-z0-9_]+(\.[a-z0-9_]+)*(-[a-zA-Z0-9]*)?$/i;
-  return regex.test(packageId);
+  let regex = /^[a-z0-9_]+(\.[a-z0-9_]+)*(-[a-zA-Z0-9]*)?$/;
+  return regex.test(packageId) ? true : 'Invalid package ID. Must match ' + regex.toString();
 };
 
 module.exports.isValidFolderName = function (folderName) {
-  let regex = /^([A-Za-z\-\_\d])+$/;
-  return regex.test(folderName);
+  let regex = /^([A-Za-z\-_\d])+$/;
+  return regex.test(folderName) ? true : 'Invalid folder name. Must match ' + regex.toString();
 };

--- a/lib/util.js
+++ b/lib/util.js
@@ -104,10 +104,8 @@ module.exports.FolderNameRegex = /^([A-Za-z\-_\d])+$/;
 
 module.exports.isValidPackageId = function (packageId) {
   return module.exports.PackageIdRegex.test(packageId);
-  // ? true : 'Invalid package ID. Must match ' + regex.toString();
 };
 
 module.exports.isValidFolderName = function (folderName) {
   return module.exports.FolderNameRegex.test(folderName);
-  // ? true : 'Invalid folder name. Must match ' + regex.toString();
 };

--- a/lib/util.js
+++ b/lib/util.js
@@ -99,12 +99,15 @@ module.exports.installPackage = function (argv) {
   }
 };
 
+module.exports.PackageIdRegex = /^[a-z0-9_]+(\.[a-z0-9_]+)*(-[a-zA-Z0-9]*)?$/;
+module.exports.FolderNameRegex = /^([A-Za-z\-_\d])+$/;
+
 module.exports.isValidPackageId = function (packageId) {
-  let regex = /^[a-z0-9_]+(\.[a-z0-9_]+)*(-[a-zA-Z0-9]*)?$/;
-  return regex.test(packageId) ? true : 'Invalid package ID. Must match ' + regex.toString();
+  return module.exports.PackageIdRegex.test(packageId);
+  // ? true : 'Invalid package ID. Must match ' + regex.toString();
 };
 
 module.exports.isValidFolderName = function (folderName) {
-  let regex = /^([A-Za-z\-_\d])+$/;
-  return regex.test(folderName) ? true : 'Invalid folder name. Must match ' + regex.toString();
+  return module.exports.FolderNameRegex.test(folderName);
+  // ? true : 'Invalid folder name. Must match ' + regex.toString();
 };

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "magic-script-cli",
   "description": "Magic Script Toolkit",
-  "version": "2.2.12",
+  "version": "2.2.13",
   "author": "Magic Leap",
   "license": "Apache-2.0",
   "bin": {


### PR DESCRIPTION
- Show error message when regex validation fails
- Do not use case-insensitive regex for app ID (causes mismatch with mabu)
- Remove redundant regex definitions and rely on common util functions
- Fix lint errors