### PR TITLE
Use child_process.spwan for 'mldb install'

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -2,7 +2,7 @@
 // Distributed under Apache 2.0 License. See LICENSE file in the project root for full license information.
 let fs = require('fs');
 let glob = require('glob');
-let { exec, execFile, execSync } = require('child_process');
+let { exec, execFile, execSync, spawn } = require('child_process');
 
 module.exports.findPackageName = function () {
   let manifestPath = 'manifest.xml';
@@ -85,16 +85,18 @@ module.exports.installPackage = function (argv) {
   if (argv.target === 'lumin') {
     let packageName = this.findPackageName();
     this.isInstalled(packageName, (installed) => {
-      let installCommand = `mldb install ${installed ? '-u' : ''} ${argv.path}`;
-      console.log(installCommand);
-      exec(installCommand, (err, stdout, stderr) => {
-        if (err) {
-          process.stdout.write(stdout);
-          process.stderr.write(stderr);
-          throw err;
-        }
-        console.log(stdout);
-      });
+      var args = ['install'];
+      if (installed) {
+        args.push('-u');
+      }
+      args.push(argv.path);
+      console.log(`mldb ${args.join(' ')}`);
+      var child = spawn('mldb', args);
+      if (child) {
+        child.stdout.on('data', (data) => {process.stdout.write(data);});
+        child.stderr.on('data', (data) => {process.stderr.write(data);});
+        child.on('error', (err) => {throw err;});
+      }
     });
   }
 };


### PR DESCRIPTION
If the stdout and/or stderr is large child_process.exec
can not handle it properly. Although we can set maxBuffSize
for exec but we never know what the proper buff size is.
spwan has a nice stream style API to address this issue.