### PR TITLE
Modify FolderNameRegex

### DIFF
--- a/__tests__/util.js
+++ b/__tests__/util.js
@@ -207,6 +207,6 @@ describe('Test Util', () => {
   });
 
   test('validateFolderName fail', () => {
-    expect(util.validateFolderName('com.#!@#te st')).toBe('Invalid folder name. Must match /^([A-Za-z\\-_\\d])+$/');
+    expect(util.validateFolderName('com.#!@#te st')).toBe('Invalid folder name. Must match /^(?:[A-Za-z\\-_\\d])+$|^\\.$/');
   });
 });

--- a/lib/util.js
+++ b/lib/util.js
@@ -102,7 +102,7 @@ module.exports.installPackage = function (argv) {
 };
 
 module.exports.PackageIdRegex = /^[a-z0-9_]+(\.[a-z0-9_]+)*(-[a-zA-Z0-9]*)?$/;
-module.exports.FolderNameRegex = /^([A-Za-z\-_\d])+$/;
+module.exports.FolderNameRegex = /^(?:[A-Za-z\-_\d])+$|^\.$/;
 
 module.exports.isValidPackageId = function (packageId) {
   return module.exports.PackageIdRegex.test(packageId);


### PR DESCRIPTION
- Allow /\./ character, to indicate "current directory"
- Make general folder regex a non-capture group

This change will allow a MagicScript project to be created in a current directory. Here is a visible test of the new combination: <https://regex101.com/r/QU8UgE/1>. Also the old regex was using a capture group on only a single character.

This was also tested on a local install of this repository from this branch.