### PR TITLE
Fix/#148 fix react hooks

### DIFF
--- a/template_multiplatform_components/lumin/package.json
+++ b/template_multiplatform_components/lumin/package.json
@@ -19,7 +19,7 @@
     "rollup": "^1.1.2",
     "rollup-plugin-babel": "^4.3.2",
     "rollup-plugin-commonjs": "^9.3.4",
-    "rollup-plugin-includepaths": "0.2.3",
+    "rollup-plugin-copy": "^3.3.0",
     "rollup-plugin-node-resolve": "^4.0.0",
     "semistandard": "^13.0.1"
   },

--- a/template_multiplatform_components/lumin/rollup.config.js
+++ b/template_multiplatform_components/lumin/rollup.config.js
@@ -1,24 +1,22 @@
 import babel from 'rollup-plugin-babel';
 import resolve from 'rollup-plugin-node-resolve';
 import commonjs from 'rollup-plugin-commonjs';
-import includePaths from 'rollup-plugin-includepaths';
-
-let includePathOptions = {
-  include: {},
-  paths: ['./src', '../src'],
-  external: []
-};
+import copy from 'rollup-plugin-copy';
 
 const common = {
   plugins: [
-    includePaths(includePathOptions),
+    copy({
+      targets: [{ src: '../src', dest: '.' }],
+      hook: 'first'
+    }),
     babel({
       exclude: 'node_modules/**'
     }),
     resolve({
       customResolveOptions: {
         moduleDirectory: '../node_modules'
-      }
+      },
+      dedupe: ['react']
     }),
     commonjs()
   ]

--- a/template_multiplatform_components/lumin/src/main.js
+++ b/template_multiplatform_components/lumin/src/main.js
@@ -7,6 +7,6 @@ import React from "react";
 import mxs from "magic-script-components-lumin";
 
 // Load main app logic from the app class.
-import MyApp from './app';
+import MyApp from '../../src/app.js';
 
 mxs.bootstrap(<MyApp type='landscape' volumeSize={[1, 1, 1]} />);


### PR DESCRIPTION
1. Add this plugin to lumin/package.json in multiplatform structure: `"rollup-plugin-copy": "^3.3.0"`
2. Update the path to app.js in the main.js to: ```import MyApp from '../../src/app.js';```
3. Update the rollup.config.js to include ```dedupe: ['react']```
