### PR TITLE
Update gradle version to 6.0.1 to fix JDK 13 compile error.

### DIFF
--- a/template_multiplatform_components/reactnative/android/gradle/wrapper/gradle-wrapper.properties
+++ b/template_multiplatform_components/reactnative/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.0.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Resolves build error: Unsupported class file major version 57