### PR TITLE
Bump ver. to 2.3.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "magic-script-cli",
   "description": "Magic Script Toolkit",
-  "version": "2.3.5",
+  "version": "2.3.6",
   "author": "Magic Leap",
   "license": "Apache-2.0",
   "bin": {


### PR DESCRIPTION
ver. 2.3.6 includes:

Updates: 
- TypeScript template
- Gradle version to 6.0.1
- Install command to use OUTNAME parameter

Fixes:
- Path for Magicverse bundle
- Release build
 