### PR TITLE
Update the magic-script-components-react-native to 1.0.5

### DIFF
--- a/template_multiplatform_components/reactnative/package.json
+++ b/template_multiplatform_components/reactnative/package.json
@@ -15,6 +15,6 @@
   "dependencies": {
     "react": "16.8.3",
     "react-native": "0.60.5",
-    "magic-script-components-react-native": "^1.0.3"
+    "magic-script-components-react-native": "^1.0.5"
   }
 }

--- a/template_overlay_typescript_components/reactnative/package.json
+++ b/template_overlay_typescript_components/reactnative/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "react": "16.8.3",
     "react-native": "0.60.5",
-    "magic-script-components-react-native": "^1.0.3"
+    "magic-script-components-react-native": "^1.0.5"
   },
   "jest": {
     "preset": "react-native",


### PR DESCRIPTION
Update the following templates with the latest `magic-script-components-react-native` ver. 1.0.5:
- template_multiplatform_components/reactnative/package.json
- template_overlay_typescript_components/reactnative/package.json