### PR TITLE
Prefer browser versions in npm dependencies

### DIFF
--- a/template/rollup.config.js
+++ b/template/rollup.config.js
@@ -12,5 +12,5 @@ export default {
     dir: 'bin',
     format: 'es'
   },
-  plugins: [polyfill(), resolve(), commonjs()]
+  plugins: [polyfill(), resolve({browser: true}), commonjs()]
 };


### PR DESCRIPTION
This is needed to support modules like uuid that have a browser version and a node version.  Our polyfills match the browser version better.